### PR TITLE
Speed-up F# code

### DIFF
--- a/F#-simple/Makefile
+++ b/F#-simple/Makefile
@@ -2,7 +2,7 @@ SRCS=fft.fs main.fs
 TARGET=benchmark.exe
 
 all:
-	fsharpc --out:$(TARGET) --optimize+ --standalone $(SRCS)
+	fsharpc --out:$(TARGET) --define:SPEED_UP $(SRCS)
 	@chmod +x $(TARGET)
 
 clean:

--- a/F#-simple/fft.fs
+++ b/F#-simple/fft.fs
@@ -16,7 +16,7 @@ module FftModule =
             phasevec_exist <- true
 
         let mutable xy_out = Array.init (1 <<< log2point) (fun _ -> Complex())
-    
+
         for i = 0 to (1 <<< log2point) - 1 do
             let mutable (brev: uint32) = uint32 i
             brev <- ((brev &&& uint32 0xaaaaaaaa) >>> 1) ||| ((brev &&& uint32 0x55555555) <<< 1)
@@ -40,7 +40,7 @@ module FftModule =
             l2pt <- l2pt + 1
 
             let mutable w_XY = Complex(1.0, 0.0)
-    
+
             for m = 0 to mmax - 1 do
                 // FIXME: slow, profile this: [m..x..n]
 #if SPEED_UP
@@ -51,14 +51,14 @@ module FftModule =
                     xy_out.[i] <- xy_out.[i] + tempXY
 
                     i <- i + istep
-#else    
+#else
                 for i in [m .. istep .. n - 1] do
                     let tempXY = w_XY * xy_out.[i + mmax]
                     xy_out.[i+mmax] <- xy_out.[i] - tempXY
                     xy_out.[i] <- xy_out.[i] + tempXY
 #endif
                 w_XY <- w_XY * wphase_XY // rotate
-        
+
             mmax <- istep
         
         xy_out

--- a/F#-simple/fft.fs
+++ b/F#-simple/fft.fs
@@ -1,6 +1,7 @@
-namespace FftPerformanceDemo
+﻿namespace FftPerformanceDemo
 
 module FftModule =
+    
     open System
     open System.Numerics
 
@@ -15,7 +16,7 @@ module FftModule =
             phasevec_exist <- true
 
         let mutable xy_out = Array.init (1 <<< log2point) (fun _ -> Complex())
-
+    
         for i = 0 to (1 <<< log2point) - 1 do
             let mutable (brev: uint32) = uint32 i
             brev <- ((brev &&& uint32 0xaaaaaaaa) >>> 1) ||| ((brev &&& uint32 0x55555555) <<< 1)
@@ -39,17 +40,25 @@ module FftModule =
             l2pt <- l2pt + 1
 
             let mutable w_XY = Complex(1.0, 0.0)
-
+    
             for m = 0 to mmax - 1 do
-                // FIXME: slow, profile this: [m..x..n]    
-                for i in [m .. istep .. n - 1] do
+                // FIXME: slow, profile this: [m..x..n]
+#if SPEED_UP
+                let mutable i = m
+                while i < n - 1 do
                     let tempXY = w_XY * xy_out.[i + mmax]
                     xy_out.[i+mmax] <- xy_out.[i] - tempXY
                     xy_out.[i] <- xy_out.[i] + tempXY
 
+                    i <- i + istep
+#else    
+                for i in [m .. istep .. n - 1] do
+                    let tempXY = w_XY * xy_out.[i + mmax]
+                    xy_out.[i+mmax] <- xy_out.[i] - tempXY
+                    xy_out.[i] <- xy_out.[i] + tempXY
+#endif
                 w_XY <- w_XY * wphase_XY // rotate
-
+        
             mmax <- istep
-
+        
         xy_out
-

--- a/F#/fft/fft.fs
+++ b/F#/fft/fft.fs
@@ -42,12 +42,21 @@ module FftModule =
             let mutable w_XY = Complex(1.0, 0.0)
     
             for m = 0 to mmax - 1 do
-                // FIXME: slow, profile this: [m..x..n]    
+                // FIXME: slow, profile this: [m..x..n]
+#if SPEED_UP
+                let mutable i = m
+                while i < n - 1 do
+                    let tempXY = w_XY * xy_out.[i + mmax]
+                    xy_out.[i+mmax] <- xy_out.[i] - tempXY
+                    xy_out.[i] <- xy_out.[i] + tempXY
+
+                    i <- i + istep
+#else    
                 for i in [m .. istep .. n - 1] do
                     let tempXY = w_XY * xy_out.[i + mmax]
                     xy_out.[i+mmax] <- xy_out.[i] - tempXY
                     xy_out.[i] <- xy_out.[i] + tempXY
-              
+#endif
                 w_XY <- w_XY * wphase_XY // rotate
         
             mmax <- istep

--- a/F#/fft/fft.fsproj
+++ b/F#/fft/fft.fsproj
@@ -20,7 +20,7 @@
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
     <OutputPath>bin\$(Configuration)\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SPEED_UP</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <DocumentationFile>bin\$(Configuration)\$(AssemblyName).XML</DocumentationFile>


### PR DESCRIPTION
HIHETETLEN GYORSULÁS!

Nálam (64 bit) 2,5×-ös gyorsulást értem el.
Persze ennek ára van: egyik nem-funkcionális kódból egy másik nem-funkcionális kód lett.
Linuxon is hasonló az eredmény (a "hivatalos" F# projekten márve)

Az egész a `[a..b..c]` -> `while` átalakítás miatt lett.
